### PR TITLE
Correct exploding of the RBKMONEY_ALLOWED_IP list

### DIFF
--- a/validation.php
+++ b/validation.php
@@ -7,7 +7,7 @@ define('RBKMONEY_ALLOWED_IP', '89.111.188.128, 89.111.188.129, 94.236.107.4, 195
 
 
 // check valid IP
-$allowed_ip = explode(',', RBKMONEY_ALLOWED_IP);
+$allowed_ip = array_map('trim', explode(',', RBKMONEY_ALLOWED_IP));
 $valid_ip = in_array($_SERVER['REMOTE_ADDR'], $allowed_ip);
 if (!$valid_ip && isset($_POST['eshopId'])) {
     Logger::AddLog('[RBK Money] Post request from not allowed IP:' . $_SERVER['REMOTE_ADDR'] . '. Status of order ID ' . stripcslashes($_POST['eshopId']) . ' not changed',


### PR DESCRIPTION
Hey, @innerfly! Your solution of exploding 

```
define('RBKMONEY_ALLOWED_IP', '89.111.188.128, 89.111.188.129');
$allowed_ip = explode(',', RBKMONEY_ALLOWED_IP);
```

returns:

```
array(2) {
  [0]=>
  string(14) "89.111.188.128"
  [1]=>
  string(14) " 195.122.9.148" // <- PLS PAY ATTETION HERE, WHITESPACE (the space at the beginning)
}
```

Added trim calling for array_map.
